### PR TITLE
Use 16 color palettes directly

### DIFF
--- a/NDS_Banner_Editor.pro
+++ b/NDS_Banner_Editor.pro
@@ -46,8 +46,6 @@ static {
     DEFINES += STATIC
 }
 
-message($$[QT_INSTALL_PREFIX])
-
 # Default rules for deployment.
 qnx: target.path = /tmp/$${TARGET}/bin
 else: unix:!android: target.path = /usr/bin

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -395,7 +395,6 @@ void MainWindow::on_gameTitle_pb_clicked()
 
 void MainWindow::on_bannerVersion_cb_currentIndexChanged(int index)
 {
-    printf("=====%d\n", index);
     constexpr int bannerVersions[] = {
         0x0001, // Normal
         0x0002, // Chinese

--- a/qndsimage.h
+++ b/qndsimage.h
@@ -33,7 +33,7 @@ private:
     int pixelDistance(QColor p1, QColor p2);
     int closestMatch(QColor pixel, const QVector<QColor> &clut, int alphaThreshold);
 
-    QVector<u16> createPalette(const QVector<QColor>& pal, int colorCount);
+    QVector<u16> createPalette(QVector<QColor> pal, int colorCount);
 };
 
 #endif // QNDSIMAGE_H


### PR DESCRIPTION
- Changes the image reading to directly use the image's palette for 16-color indexed images
   - This allows much greater control over the palettes, such as in my Wordle DS icon where I used palette swapping to reuse the same frame several times
   - Also uses the palette instead of creating a new one for 256-color indexed images, but still reduces those as the higher colors are likely used
- Also removes a couple leftover debug prints