### PR TITLE
Export as 16-color indexed images

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -92,7 +92,7 @@ void MainWindow::getBinaryIconPtr(u8*& ncg, u16*& ncl, int bmpID, int palID)
     }
 }
 
-QPixmap MainWindow::getCurrentPixmap(int bmpID, int palID)
+QImage MainWindow::getCurrentImage(int bmpID, int palID)
 {
     u8* ncg;
     u16* ncl;
@@ -102,7 +102,12 @@ QPixmap MainWindow::getCurrentPixmap(int bmpID, int palID)
     QVector<u16> nclV = QVector<u16>(ncl, ncl + 0x10);
 
     QNDSImage ndsImg(ncgV, nclV, true);
-    return QPixmap::fromImage(ndsImg.toImage(4));
+    return ndsImg.toImage(4);
+}
+
+QPixmap MainWindow::getCurrentPixmap(int bmpID, int palID)
+{
+    return QPixmap::fromImage(getCurrentImage(bmpID, palID));
 }
 
 void MainWindow::updateIconView(int bmpID, int palID)
@@ -636,7 +641,7 @@ void MainWindow::on_gfxExport_pb_clicked()
 {
     int bmpID = ui->gfxBmp_sb->value() - 1;
     int palID = ui->gfxPal_sb->value() - 1;
-    QPixmap pixmap = getCurrentPixmap(bmpID, palID);
+    QImage image = getCurrentImage(bmpID, palID);
 
     QString fileName = QFileDialog::getSaveFileName(this, "", this->lastDirPath, tr("PNG Files") + " (*.png)");
     if(fileName == "")
@@ -650,6 +655,6 @@ void MainWindow::on_gfxExport_pb_clicked()
         QMessageBox::critical(this, "Big OOF", tr("Could not open file for writing."));
         return;
     }
-    pixmap.save(&file, "PNG");
+    image.save(&file, "PNG");
     file.close();
 }

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -108,6 +108,7 @@ private:
     QString openedFileName;
     QGraphicsScene gfx_scene;
 
+    QImage getCurrentImage(int bmpID, int palID);
     QPixmap getCurrentPixmap(int bmpID, int palID);
 
     int gfxBmp_lastValue = 0;

--- a/qndsimage.cpp
+++ b/qndsimage.cpp
@@ -187,19 +187,18 @@ QImage QNDSImage::toImage(int tileWidth)
     const int width = tileWidth * 8;
     const int height = texture.size() / width;
 
-    QImage out(width, height, QImage::Format_ARGB32);
-    out.fill(Qt::transparent);
+    QImage out(width, height, QImage::Format_Indexed8);
+
+    QVector<QRgb> pal;
+    for(u16 color : this->palette)
+        pal.append(0xFF000000 | toRgb24(color));
+    pal[0] &= 0x00FFFFFF; // Make color 0 transparent
+    out.setColorTable(pal);
 
     QVector<u8> tiled = getTiled(tileWidth, false);
     for(int i = 0, y = 0; y < height; y++) {
-        for(int x = 0; x < width; x++, i++)
-        {
-            int colorIndex = tiled[i];
-            if(colorIndex != 0)
-            {
-                QColor c = toRgb24(palette[colorIndex]);
-                out.setPixelColor(x, y, c);
-            }
+        for(int x = 0; x < width; x++, i++) {
+            out.setPixel(x, y, tiled[i]);
         }
     }
 


### PR DESCRIPTION
Changes the exported image to be a 16-color indexed image instead of 32-bit RGBA image, keeping it more accurate to what it actually is. This allows exporting the image and looking at the colormap in programs such as GIMP.