### PR TITLE
Fix a couple bugs

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -199,8 +199,6 @@ void MainWindow::on_actionOpen_triggered()
 
 bool MainWindow::loadFile(const QString& path, bool isNew)
 {
-    setProgramState(isNew ? ProgramState::NewFile : ProgramState::KnowsPath);
-
     if(!isNew)
     {
         this->openedFileName = path;
@@ -230,6 +228,8 @@ bool MainWindow::loadFile(const QString& path, bool isNew)
     memset(&this->bannerBin, 0, sizeof(NDSBanner));
     memcpy(&this->bannerBin, file.readAll().data(), fileSize);
     file.close();
+
+    setProgramState(isNew ? ProgramState::NewFile : ProgramState::KnowsPath);
 
     /* ======== ICON SETUP ======== */
 

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -193,22 +193,28 @@ void MainWindow::on_actionOpen_triggered()
     QString fileName = QFileDialog::getOpenFileName(this, "", this->lastDirPath, tr("Banner Files") + " (*.bin)");
     if(fileName == "")
         return;
-    this->openedFileName = fileName;
-
-    QFileInfo fileInfo(fileName);
-    this->lastDirPath = fileInfo.dir().path();
-
-    if(fileInfo.size() != sizeof(NDSBanner) && fileInfo.size() != 0x840 && fileInfo.size() != 0x940 && fileInfo.size() != 0xA40)
-    {
-        QMessageBox::information(this, tr("Oops!"), tr("Invalid banner size.\nMake sure this is a valid banner file."));
-        return;
-    }
 
     loadFile(fileName, false);
 }
 
 bool MainWindow::loadFile(const QString& path, bool isNew)
 {
+    setProgramState(isNew ? ProgramState::NewFile : ProgramState::KnowsPath);
+
+    if(!isNew)
+    {
+        this->openedFileName = path;
+
+        QFileInfo fileInfo(path);
+        this->lastDirPath = fileInfo.dir().path();
+
+        if(fileInfo.size() != sizeof(NDSBanner) && fileInfo.size() != 0x840 && fileInfo.size() != 0x940 && fileInfo.size() != 0xA40)
+        {
+            QMessageBox::information(this, tr("Oops!"), tr("Invalid banner size.\nMake sure this is a valid banner file."));
+            return false;
+        }
+    }
+
     QFile file(path);
     if(!file.open(QIODevice::ReadOnly))
     {
@@ -257,8 +263,6 @@ bool MainWindow::loadFile(const QString& path, bool isNew)
     if(this->bannerBin.animData[0].frameDuration)
         setAnimGroupEnabled(true);
     on_animFrame_cb_currentIndexChanged(0);
-
-    setProgramState(isNew ? ProgramState::NewFile : ProgramState::KnowsPath);
 
     return true;
 }


### PR DESCRIPTION
This just fixes a couple small bugs I noticed:
- Drag dropping a file wasn't setting the saved path, since I missed moving that part into `loadFile()`
- Chinese/Korean weren't being grayed out on loading a banner that doesn't support those as the dropdown was still locked, so moved that to the top of loading